### PR TITLE
refine stage card and chip styling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -84,7 +84,7 @@ const Index = () => {
       {/* Stage Selection */}
       <div className="px-6 flex-1">
         <div
-          className="inline-block px-6 py-3 rounded-full bg-white/5 backdrop-blur-sm border border-cyan-400/30 shadow-lg shadow-cyan-400/10 mb-6"
+          className="inline-block px-6 py-3 rounded-full bg-white/5 backdrop-blur-sm border border-cyan-400/40 shadow-lg shadow-cyan-400/10 mb-6"
           data-spec-id="stage-selection-chip"
         >
           <span className="text-cyan-300 font-medium">Stage Selection</span>

--- a/components/stage-card.tsx
+++ b/components/stage-card.tsx
@@ -9,12 +9,12 @@ export function StageCard({ stage, onClick }: StageCardProps) {
   return (
     <Button
       onClick={() => onClick(stage)}
-      className="h-24 rounded-2xl bg-white/10 backdrop-blur-sm border border-cyan-400/30 hover:bg-white/20 hover:border-cyan-400/50 transition-all duration-300 shadow-lg shadow-cyan-400/10 hover:shadow-cyan-400/20 flex flex-col gap-2"
+      className="h-24 rounded-2xl bg-white/5 backdrop-blur-sm border border-cyan-400/40 hover:bg-white/10 hover:border-cyan-400/60 transition-all duration-300 shadow-lg shadow-cyan-400/10 hover:shadow-[0_0_20px_-6px_rgba(56,189,248,.45)] flex flex-col gap-2"
       variant="ghost"
       data-spec-id={`stage-${stage}-card`}
     >
       <span className="text-xl font-bold text-white">Stage {stage}</span>
-      <span className="text-sm text-cyan-200/70">Tap to open</span>
+      <span className="text-sm text-cyan-300">Tap to open</span>
     </Button>
   )
 }


### PR DESCRIPTION
## Summary
- align stage cards with design: lighter cyan border, soft background, and glowing hover shadow
- match stage-selection chip colors with cards for unified theme

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a76ff2f7008321b15fb83ca24594b2